### PR TITLE
(feat) limit the number of lab orders to the most recent and improve UI

### DIFF
--- a/src/queue-list/laboratory-patient-list.component.tsx
+++ b/src/queue-list/laboratory-patient-list.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useMemo, useState } from "react";
 import {
   DataTable,
   DataTableSkeleton,
@@ -7,48 +7,32 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableExpandHeader,
-  TableExpandRow,
-  OverflowMenuItem,
-  OverflowMenu,
   TableHead,
   TableHeader,
   TableRow,
-  TabPanel,
   TableToolbar,
   TableToolbarContent,
   TableToolbarSearch,
   Layer,
   Tag,
-  TableExpandedRow,
   Tile,
-  Button,
   DatePicker,
   DatePickerInput,
 } from "@carbon/react";
-import { TrashCan, OverflowMenuVertical } from "@carbon/react/icons";
-
+import { OverflowMenuVertical } from "@carbon/react/icons";
 import { useTranslation } from "react-i18next";
 import {
   ExtensionSlot,
-  age,
   formatDate,
-  formatDatetime,
   parseDate,
-  showModal,
   usePagination,
-  useSession,
 } from "@openmrs/esm-framework";
 import styles from "./laboratory-queue.scss";
 import { getStatusColor } from "../utils/functions";
-import { Result, useGetOrdersWorklist } from "../work-list/work-list.resource";
+import { useGetOrdersWorklist } from "../work-list/work-list.resource";
 import OrderCustomOverflowMenuComponent from "../ui-components/overflow-menu.component";
 
 interface LaboratoryPatientListProps {}
-
-interface RejectOrderProps {
-  order: Result;
-}
 
 const LaboratoryPatientList: React.FC<LaboratoryPatientListProps> = () => {
   const { t } = useTranslation();

--- a/src/queue-list/laboratory-queue.scss
+++ b/src/queue-list/laboratory-queue.scss
@@ -122,11 +122,6 @@ title {
     border-bottom: none;
   }
 }
-.headerBtnContainer {
-  background-color: $ui-background;
-  padding: spacing.$spacing-05;
-  text-align: right;
-}
 
 .searchContainer {
   display: flex;

--- a/src/queue-list/laboratory-tabs.component.tsx
+++ b/src/queue-list/laboratory-tabs.component.tsx
@@ -1,20 +1,15 @@
 import React, { useEffect, useMemo, useState } from "react";
 import {
   type AssignedExtension,
-  Extension,
   ExtensionSlot,
   useConnectedExtensions,
   attach,
   detachAll,
 } from "@openmrs/esm-framework";
-import { Tab, Tabs, TabList, TabPanels, TabPanel, Search } from "@carbon/react";
+import { Tab, Tabs, TabList, TabPanels, TabPanel } from "@carbon/react";
 import { useTranslation } from "react-i18next";
 import styles from "./laboratory-queue.scss";
 import LaboratoryPatientList from "./laboratory-patient-list.component";
-import { EmptyState } from "@openmrs/esm-patient-common-lib";
-import WorkList from "../work-list/work-list.component";
-import ReviewList from "../review-list/review-list.component";
-import CompletedList from "../completed-list/completed-list.component";
 
 enum TabTypes {
   STARRED,
@@ -54,7 +49,6 @@ const LaboratoryQueueTabs: React.FC = () => {
       return (
         <TabPanel key={extension.meta.name} style={{ padding: 0 }}>
           <div>
-            <div className={styles.headerBtnContainer}></div>
             <ExtensionSlot name={slotName} />
           </div>
         </TabPanel>
@@ -113,10 +107,7 @@ const LaboratoryQueueTabs: React.FC = () => {
           </TabList>
           <TabPanels>
             <TabPanel style={{ padding: 0 }}>
-              <div>
-                <div className={styles.headerBtnContainer}></div>
-                <LaboratoryPatientList />
-              </div>
+              <LaboratoryPatientList />
             </TabPanel>
             {extraPanels}
           </TabPanels>

--- a/src/summary-tiles/laboratory-summary-tiles.scss
+++ b/src/summary-tiles/laboratory-summary-tiles.scss
@@ -6,7 +6,6 @@
   background-color: $ui-02 ;
   display: flex;
   justify-content: space-between;
-  padding: 0 spacing.$spacing-05 spacing.$spacing-10 spacing.$spacing-03;
   flex-flow: row wrap;
   margin-top: - spacing.$spacing-03;
 }

--- a/src/work-list/work-list.resource.ts
+++ b/src/work-list/work-list.resource.ts
@@ -120,7 +120,7 @@ export function useGetOrdersWorklist(
   activatedOnOrAfterDate: string,
   fulfillerStatus: string
 ) {
-  const apiUrl = `/ws/rest/v1/order?orderTypes=52a447d3-a64a-11e3-9aeb-50e549534c5e&activatedOnOrAfterDate=${activatedOnOrAfterDate}&isStopped=false&fulfillerStatus=${fulfillerStatus}&v=full
+  const apiUrl = `/ws/rest/v1/order?orderTypes=52a447d3-a64a-11e3-9aeb-50e549534c5e&activatedOnOrAfterDate=${activatedOnOrAfterDate}&isStopped=false&fulfillerStatus=${fulfillerStatus}&v=full&limit=200
 `;
 
   const { data, error, isLoading } = useSWR<


### PR DESCRIPTION
## Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.
- [ ] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR tries to improve performance of fetching lab orders by limiting the number of orders fetched from backend, I have also include a number of UI enhancements to make the dashboard appear consistent with other apps.

@ojwanganto Including `activatedOnOrAfterDate` leads to a lot of re-rendering

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
